### PR TITLE
fix: Vercel build (rutas home/paginación)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,13 +1,15 @@
-# Added by Payload
-PREVIEW_SECRET=YOUR_SECRET_HERE
-# Used to validate preview requests
-CRON_SECRET=YOUR_CRON_SECRET_HERE
-# Secret used to authenticate cron jobs
+# === Public URL (dev) ===
+# En local: dejar http://localhost:3000
+# En Vercel: en PREVIEW/PRODUCTION poner la URL real del deploy (sin barra final)
 NEXT_PUBLIC_SERVER_URL=http://localhost:3000
-# Used to configure CORS, format links and more. No trailing slash
-PAYLOAD_SECRET=1aa144b276358b34dbe8942f
-# Used to encrypt JWT tokens
-#DATABASE_URI=postgresql://127.0.0.1:5432/your-database-name
-# Or use a PG connection string
+
+# === Payload secrets ===
+PAYLOAD_SECRET=__REPLACE_ME__
+PREVIEW_SECRET=__REPLACE_ME__
+CRON_SECRET=__REPLACE_ME__
+
+# === Database ===
 DATABASE_URI=file:./la-productora-films.db
-# Database connection string
+
+# Producción (Postgres) — ejemplo de formato:
+# DATABASE_URI=postgres://USER:PASSWORD@HOST:PORT/DB?sslmode=require

--- a/.gitignore
+++ b/.gitignore
@@ -1,17 +1,51 @@
-build
-dist / media
-node_modules
+# === OS / IDE ===
 .DS_Store
-.env
-.next
-.vercel
-.idea
+Thumbs.db
+.idea/
+.vscode/
 
-# Payload default media upload directory
+# === Node / package managers ===
+node_modules/
+npm-debug.log*
+pnpm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# No usamos estos lockfiles (estamos con pnpm)
+package-lock.json
+yarn.lock
+
+# === Next.js ===
+.next/
+.next/cache/
+out/
+
+# === Vercel CLI (link local) ===
+.vercel/
+
+# === Builds genéricos ===
+build/
+dist/
+
+# === Payload CMS ===
+# uploads locales (no versionar)
 public/media/
 
+# === Environment files (secretos) ===
+.env
+.env.local
+.env.*.local
+.env.test
+.env.production
+.env.development
+
+
+# === Misc estáticos que se regeneran ===
 public/robots.txt
 public/sitemap*.xml
 
-package-lock.json
-yarn.lock
+# === Caches / herramientas ===
+.eslintcache
+.turbo/
+.swc/
+.cache/

--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -1,5 +1,0 @@
-import PageTemplate, { generateMetadata } from './[slug]/page'
-
-export default PageTemplate
-
-export { generateMetadata }

--- a/src/app/(frontend)/posts/[slug]/page.tsx
+++ b/src/app/(frontend)/posts/[slug]/page.tsx
@@ -1,10 +1,14 @@
+// src/app/(frontend)/posts/[slug]/page.tsx
+
+export const dynamic = 'force-static'
+export const revalidate = 600 // revalida cada 10 minutos (ajustá si querés)
+
 import type { Metadata } from 'next'
 
 import { RelatedPosts } from '@/blocks/RelatedPosts/Component'
 import { PayloadRedirects } from '@/components/PayloadRedirects'
 import configPromise from '@payload-config'
 import { getPayload } from 'payload'
-import { draftMode } from 'next/headers'
 import React, { cache } from 'react'
 import RichText from '@/components/RichText'
 
@@ -13,7 +17,9 @@ import type { Post } from '@/payload-types'
 import { PostHero } from '@/heros/PostHero'
 import { generateMeta } from '@/utilities/generateMeta'
 import PageClient from './page.client'
-import { LivePreviewListener } from '@/components/LivePreviewListener'
+// ⚠️ Quitamos draftMode y LivePreviewListener para no marcar la ruta como dinámica
+// import { draftMode } from 'next/headers'
+// import { LivePreviewListener } from '@/components/LivePreviewListener'
 
 export async function generateStaticParams() {
   const payload = await getPayload({ config: configPromise })
@@ -23,16 +29,10 @@ export async function generateStaticParams() {
     limit: 1000,
     overrideAccess: false,
     pagination: false,
-    select: {
-      slug: true,
-    },
+    select: { slug: true },
   })
 
-  const params = posts.docs.map(({ slug }) => {
-    return { slug }
-  })
-
-  return params
+  return posts.docs.map(({ slug }) => ({ slug }))
 }
 
 type Args = {
@@ -42,7 +42,6 @@ type Args = {
 }
 
 export default async function Post({ params: paramsPromise }: Args) {
-  const { isEnabled: draft } = await draftMode()
   const { slug = '' } = await paramsPromise
   const url = '/posts/' + slug
   const post = await queryPostBySlug({ slug })
@@ -53,10 +52,11 @@ export default async function Post({ params: paramsPromise }: Args) {
     <article className="pt-16 pb-16">
       <PageClient />
 
-      {/* Allows redirects for valid pages too */}
+      {/* Permite redirects para páginas válidas también */}
       <PayloadRedirects disableNotFound url={url} />
 
-      {draft && <LivePreviewListener />}
+      {/* Quitar LivePreviewListener para no forzar dynamic en build */}
+      {/* {draft && <LivePreviewListener />} */}
 
       <PostHero post={post} />
 
@@ -66,7 +66,7 @@ export default async function Post({ params: paramsPromise }: Args) {
           {post.relatedPosts && post.relatedPosts.length > 0 && (
             <RelatedPosts
               className="mt-12 max-w-[52rem] lg:grid lg:grid-cols-subgrid col-start-1 col-span-3 grid-rows-[2fr]"
-              docs={post.relatedPosts.filter((post) => typeof post === 'object')}
+              docs={post.relatedPosts.filter((p) => typeof p === 'object')}
             />
           )}
         </div>
@@ -78,27 +78,20 @@ export default async function Post({ params: paramsPromise }: Args) {
 export async function generateMetadata({ params: paramsPromise }: Args): Promise<Metadata> {
   const { slug = '' } = await paramsPromise
   const post = await queryPostBySlug({ slug })
-
   return generateMeta({ doc: post })
 }
 
 const queryPostBySlug = cache(async ({ slug }: { slug: string }) => {
-  const { isEnabled: draft } = await draftMode()
-
   const payload = await getPayload({ config: configPromise })
 
   const result = await payload.find({
     collection: 'posts',
-    draft,
+    draft: false, // <- fijo para SSG
+    overrideAccess: false, // <- fijo para SSG
     limit: 1,
-    overrideAccess: draft,
     pagination: false,
-    where: {
-      slug: {
-        equals: slug,
-      },
-    },
+    where: { slug: { equals: slug } },
   })
 
-  return result.docs?.[0] || null
+  return (result.docs?.[0] as Post | undefined) ?? null
 })

--- a/src/app/(frontend)/posts/page.tsx
+++ b/src/app/(frontend)/posts/page.tsx
@@ -9,6 +9,7 @@ import React from 'react'
 import PageClient from './page.client'
 
 export const dynamic = 'force-static'
+export const dynamicParams = false
 export const revalidate = 600
 
 export default async function Page() {


### PR DESCRIPTION
Este PR arregla el fallo de build en Vercel:

- Remueve ruta duplicada de `/` en `app/(frontend)/page.tsx` (quedó solo la Home en `(home)/page.tsx`).
- Ajusta `/posts/[slug]` y `/posts/page/[pageNumber]` para que Vercel genere las lambdas correctamente.

